### PR TITLE
Adds ScmStartedEvent which is fired after all init scripts are executed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
+- Added `ScmStartedEvent` which is fired after all init scripts are executed ([#11](https://github.com/scm-manager/scm-script-plugin/pull/11))
 - Documentation in English and German ([#8](https://github.com/scm-manager/scm-script-plugin/pull/8))
 
 ## [2.0.0] - 2020-06-04

--- a/src/main/java/sonia/scm/script/infrastructure/ScmStartedEvent.java
+++ b/src/main/java/sonia/scm/script/infrastructure/ScmStartedEvent.java
@@ -1,0 +1,33 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package sonia.scm.script.infrastructure;
+
+import sonia.scm.event.Event;
+
+/**
+ * Event which is fired after SCM-Manager has finished starting.
+ */
+@Event
+public class ScmStartedEvent {
+}

--- a/src/test/java/sonia/scm/script/infrastructure/InitScriptContextListenerTest.java
+++ b/src/test/java/sonia/scm/script/infrastructure/InitScriptContextListenerTest.java
@@ -32,6 +32,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import sonia.scm.event.ScmEventBus;
 import sonia.scm.script.domain.ExecutionContext;
 import sonia.scm.script.domain.Executor;
 import sonia.scm.script.domain.InitScript;
@@ -56,6 +57,9 @@ class InitScriptContextListenerTest {
 
   @Mock
   private Executor executor;
+
+  @Mock
+  private ScmEventBus eventBus;
 
   @InjectMocks
   private InitScriptContextListener listener;
@@ -84,6 +88,7 @@ class InitScriptContextListenerTest {
 
     verify(executor, times(2)).execute(scriptCaptor.capture(), any(ExecutionContext.class));
     assertThat(scriptCaptor.getAllValues()).containsOnly(one, two);
+    verify(eventBus).post(any(ScmStartedEvent.class));
   }
 
   private InitScript createScript(String one) {


### PR DESCRIPTION
## Proposed changes

Adds ScmStartedEvent which is fired after all init scripts are executed. This is useful for scripts which should do initial configuration.

### Your checklist for this pull request

- [X] PR is well described
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [X] CHANGELOG.md updated
- [X] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
