### PR TITLE
Fixes loading of plugin classes in a script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+### Fixed
+- Loading of plugin classes in a script ([#13](https://github.com/scm-manager/scm-script-plugin/pull/13))
+
 ### Added
 - Documentation in English and German ([#8](https://github.com/scm-manager/scm-script-plugin/pull/8))
 


### PR DESCRIPTION
## Proposed changes

This change will set the context classloader to the UberClassLoader before the script engine is loaded.
The script engine stores the context classloader as parent for script execution.
With this change it is now possible to import every class from every installed plugin.

Now it is possible to write scripts like the following:

```groovy
import sonia.scm.jenkins.JenkinsContext
def context = injector.getInstance(JenkinsContext.class)
```

Instead of:

```groovy
def contextClass = Class.forName("sonia.scm.jenkins.JenkinsContext", true, Thread.currentThread().getContextClassLoader())
def context = injector.getInstance(contextClass)
```

### Your checklist for this pull request

- [X] PR is well described
- [X] Related issues linked to PR if existing and labels set
- [X] Target branch is not master (in most cases develop should bet the target of choice) 
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [X] CHANGELOG.md updated

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
