### PR TITLE
Fix background in high contrast mode

### DIFF
--- a/gradle/changelog/table_color.yaml
+++ b/gradle/changelog/table_color.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Fix background in high contrast mode ([#38](https://github.com/scm-manager/scm-script-plugin/pull/38))

--- a/src/main/js/components/ListenersTable.tsx
+++ b/src/main/js/components/ListenersTable.tsx
@@ -47,10 +47,6 @@ const VCenteredTd = styled.td`
   vertical-align: middle !important;
 `;
 
-const DarkerVCenteredTd = styled(VCenteredTd)`
-  background-color: whitesmoke;
-`;
-
 class ListenersTable extends React.Component<Props> {
   checkedIcon = (checked: boolean) => {
     if (checked) {
@@ -95,13 +91,13 @@ class ListenersTable extends React.Component<Props> {
 
     return (
       <tr>
-        <DarkerVCenteredTd>
+        <VCenteredTd className={"has-background-secondary-less"}>
           <Select name="eventType" options={options} value={eventType} onChange={onChange} />
-        </DarkerVCenteredTd>
-        <DarkerVCenteredTd>
+        </VCenteredTd>
+        <VCenteredTd className={"has-background-secondary-less"}>
           <Checkbox name="asynchronous" checked={asynchronous} onChange={onChange} />
-        </DarkerVCenteredTd>
-        <DarkerVCenteredTd>
+        </VCenteredTd>
+        <VCenteredTd className={"has-background-secondary-less"}>
           <Icon
             name="plus"
             color="inherit"
@@ -109,7 +105,7 @@ class ListenersTable extends React.Component<Props> {
             title={t("scm-script-plugin.listeners.add")}
             onClick={onSubmit}
           />
-        </DarkerVCenteredTd>
+        </VCenteredTd>
       </tr>
     );
   };


### PR DESCRIPTION
## Proposed changes

The table for listeners had a hard coded white background, making it unusable in high contrast mode. This removes the color and uses the appropriate css class.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
